### PR TITLE
Update dependencies and documentation link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "apicache": "^1.6.3",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
-        "express": "^4.22.1",
+        "express": "^4.22.2",
         "express-rate-limit": "^8.5.1",
         "morgan": "^1.10.1",
         "pug": "^3.0.4",
@@ -640,14 +640,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -666,7 +666,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -701,21 +701,6 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
-      }
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fill-range": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "apicache": "^1.6.3",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
-    "express": "^4.22.1",
+    "express": "^4.22.2",
     "express-rate-limit": "^8.5.1",
     "morgan": "^1.10.1",
     "pug": "^3.0.4",

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -459,7 +459,7 @@ block content
             | dokümantasyon sayfamızı ziyaret edebilirsiniz. Yeni dokümantasyon
             | sayfası, API'nin nasıl kullanılacağına dair kapsamlı bilgiler
             | sunmaktadır.
-          a.new-docs-card__button(href='https://docs.turkiyeapi.dev/' target='_blank')
+          a.new-docs-card__button(href='https://docs.turkiyeapi.dev/tr' target='_blank')
             | Yeni Dokümantasyonu İncele
         else
           h2.new-docs-card__title Want to try the new documentation?


### PR DESCRIPTION
Update the documentation link to point to the Turkish version and upgrade the express and body-parser dependencies to their latest versions.