### PR TITLE
Update dependencies and documentation links for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ What's new in v2:
 
 Base v2 URL: `https://api.turkiyeapi.dev/v2`
 
-[Documentation for v2](https://github.com/ubeydeozdmr/turkiye-api/tree/v2#readme)
+[v2 GitHub Source Code](https://github.com/ubeydeozdmr/turkiye-api/tree/v2)
+
+[v2 Documentation (Guide)](https://docs.turkiyeapi.dev/tr/v2/guide/)
+
+[v2 Documentation (API Reference)](https://docs.turkiyeapi.dev/tr/v2/api-reference/)
 
 [Postman Collection for v2](https://documenter.getpostman.com/view/19561492/UzBguVHM)
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -36,7 +36,11 @@ v2'deki yenilikler:
 
 Temel v2 URL: `https://api.turkiyeapi.dev/v2`
 
-[v2 için Dokümantasyon](https://github.com/ubeydeozdmr/turkiye-api/tree/v2#readme)
+[v2 GitHub Kaynak Kodu](https://github.com/ubeydeozdmr/turkiye-api/tree/v2)
+
+[v2 için Dokümantasyon (Rehber)](https://docs.turkiyeapi.dev/tr/v2/guide/)
+
+[v2 için Dokümantasyon (API Referansı)](https://docs.turkiyeapi.dev/tr/v2/api-reference/)
 
 [v2 için Postman Koleksiyonu](https://documenter.getpostman.com/view/19561492/UzBguVHM)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^4.22.2",
-        "express-rate-limit": "^8.5.1",
+        "express-rate-limit": "^8.5.2",
         "morgan": "^1.10.1",
         "pug": "^3.0.4",
         "swagger-jsdoc": "^6.2.8",
@@ -686,9 +686,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
-      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^4.22.2",
-    "express-rate-limit": "^8.5.1",
+    "express-rate-limit": "^8.5.2",
     "morgan": "^1.10.1",
     "pug": "^3.0.4",
     "swagger-jsdoc": "^6.2.8",

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -419,7 +419,7 @@ block content
           | Bir daha gösterme
         .modal__buttons
           button.modal__btn-dismiss#v2-modal-dismiss Kapat
-          a.modal__btn-primary(href='https://github.com/ubeydeozdmr/turkiye-api/tree/v2#readme' target='_blank' onclick='document.getElementById("v2-modal-dismiss").click()') Daha Fazla Bilgi
+          a.modal__btn-primary(href='https://docs.turkiyeapi.dev/tr/v2/guide/' target='_blank' onclick='document.getElementById("v2-modal-dismiss").click()') Daha Fazla Bilgi
       else
         h2.modal__title#v2-modal-title About version 2
         p.modal__description
@@ -429,16 +429,16 @@ block content
           | Don't show this again
         .modal__buttons
           button.modal__btn-dismiss#v2-modal-dismiss Dismiss
-          a.modal__btn-primary(href='https://github.com/ubeydeozdmr/turkiye-api/tree/v2#readme' target='_blank' onclick='document.getElementById("v2-modal-dismiss").click()') Learn More
+          a.modal__btn-primary(href='https://docs.turkiyeapi.dev/en/v2/guide/' target='_blank' onclick='document.getElementById("v2-modal-dismiss").click()') Learn More
   .banner
     if language && language.startsWith('tr')
       | TurkiyeAPI versiyon 2'nin önizlemesi herkese açık olarak yayınlandı! Haziran ayında ise tam olarak yayınlanacak, ancak bu süreç içerisinde v2'yi kullanıp geri bildirimde bulunabilirsiniz.
-      a(href='https://github.com/ubeydeozdmr/turkiye-api/tree/v2#readme' target='_blank' style='color: turquoise; text-decoration: underline; margin-left: 5px') Dokümantasyon
+      a(href='https://docs.turkiyeapi.dev/tr/v2/guide/' target='_blank' style='color: turquoise; text-decoration: underline; margin-left: 5px') Dokümantasyon
       |  /
       a(href='https://github.com/ubeydeozdmr/turkiye-api/issues/58#issuecomment-4358464318' target='_blank' style='color: turquoise; text-decoration: underline; margin-left: 5px') Geri Bildirim Sağla
     else
       | A preview of TurkiyeAPI version 2 has been publicly released! The full release will be in June, but in the meantime, you can use v2 and provide feedback.
-      a(href='https://github.com/ubeydeozdmr/turkiye-api/tree/v2#readme' target='_blank' style='color: turquoise; text-decoration: underline; margin-left: 5px') Documentation
+      a(href='https://docs.turkiyeapi.dev/en/v2/guide/' target='_blank' style='color: turquoise; text-decoration: underline; margin-left: 5px') Documentation
       |  /
       a(href='https://github.com/ubeydeozdmr/turkiye-api/issues/58#issuecomment-4358464318' target='_blank' style='color: turquoise; text-decoration: underline; margin-left: 5px') Provide Feedback
   header.hero


### PR DESCRIPTION
Upgrade the `express-rate-limit` dependency to the latest version and update various documentation links in the README and modal to point to the correct resources for version 2.